### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Composer will download the package. After the package is downloaded, open config
 
 'providers' => array(
     ...
-    'Ognjenm\ReservationsCalendar\ReservationsCalendarServiceProvider:class',
+    'Ognjenm\ReservationsCalendar\ReservationsCalendarServiceProvider',
 ),
 
 
 
 'aliases' => array(
     ...
-    'ResCalendar'     => 'Ognjenm\ReservationsCalendar\Facades\ResCalendar:class',
+    'ResCalendar'     => 'Ognjenm\ReservationsCalendar\Facades\ResCalendar',
 ),
 
 ```


### PR DESCRIPTION
Correct old instructions to new one for using this in Laravel 5.1, removing the :class at the end of the two inclusions in app.php
